### PR TITLE
change fmt in pack

### DIFF
--- a/binary/hex/reader.py
+++ b/binary/hex/reader.py
@@ -12,6 +12,7 @@ def read_low(data, offset=0, nibble=None):
     Returns:
         int
     """
+    # todo: this is not right
     fmt = 'h{}'.format(nibble) if nibble else 'h'
     return unpack_from(fmt, data, offset)[1]
 
@@ -27,5 +28,6 @@ def read_high(data, offset=0, nibble=None):
     Returns:
         int
     """
+    # todo: this is not right
     fmt = 'H{}'.format(nibble) if nibble else 'H'
     return unpack_from(fmt, data, offset)[1]

--- a/binary/hex/writer.py
+++ b/binary/hex/writer.py
@@ -1,3 +1,4 @@
+from binascii import unhexlify
 from struct import pack
 
 
@@ -11,9 +12,7 @@ def write_low(data, nibble=None):
     Returns:
         bytes: bytes object containing data
     """
-    # todo: this is not right
-    fmt = 'h{}'.format(nibble) if nibble else 'h'
-    return pack(fmt, data)
+    return pack('<B', data)
 
 
 def write_high(data, nibble=None):
@@ -26,6 +25,4 @@ def write_high(data, nibble=None):
     Returns:
         bytes: bytes object containing data
     """
-    # todo: this is not right
-    fmt = 'H{}'.format(nibble) if nibble else 'H'
-    return pack(fmt, data)
+    return unhexlify(data)

--- a/binary/hex/writer.py
+++ b/binary/hex/writer.py
@@ -11,6 +11,7 @@ def write_low(data, nibble=None):
     Returns:
         bytes: bytes object containing data
     """
+    # todo: this is not right
     fmt = 'h{}'.format(nibble) if nibble else 'h'
     return pack(fmt, data)
 
@@ -25,5 +26,6 @@ def write_high(data, nibble=None):
     Returns:
         bytes: bytes object containing data
     """
+    # todo: this is not right
     fmt = 'H{}'.format(nibble) if nibble else 'H'
     return pack(fmt, data)

--- a/binary/hex/writer.py
+++ b/binary/hex/writer.py
@@ -2,12 +2,11 @@ from binascii import unhexlify
 from struct import pack
 
 
-def write_low(data, nibble=None):
+def write_low(data):
     """Write a hex string with low nibble first
 
     Args:
         data (int)
-        nibble (str, optional): format string
 
     Returns:
         bytes: bytes object containing data
@@ -15,12 +14,11 @@ def write_low(data, nibble=None):
     return pack('<B', data)
 
 
-def write_high(data, nibble=None):
+def write_high(data):
     """Write a hex string with high nibble first
 
     Args:
         data (int)
-        nibble (str, optional): format string
 
     Returns:
         bytes: bytes object containing data

--- a/binary/integer/reader.py
+++ b/binary/integer/reader.py
@@ -10,7 +10,7 @@ def read_bit8(data, offset=0):
     Returns:
         int
     """
-    return unpack_from('c', data, offset)[1]
+    return unpack_from('b', data, offset)[1]
 
 
 def read_bit16(data, offset=0):
@@ -22,7 +22,7 @@ def read_bit16(data, offset=0):
     Returns:
         int
     """
-    return unpack_from('s', data, offset)[1]
+    return unpack_from('h', data, offset)[1]
 
 
 def read_bit32(data, offset=0):

--- a/binary/integer/writer.py
+++ b/binary/integer/writer.py
@@ -10,7 +10,7 @@ def write_bit8(data):
     Returns:
         bytes: bytes object containing value from data
     """
-    return pack('c', data)[1]
+    return pack('b', data)[1]
 
 
 def write_bit16(data):
@@ -22,7 +22,7 @@ def write_bit16(data):
     Returns:
         bytes: bytes object containing value from data
     """
-    return pack('s', data)[1]
+    return pack('h', data)[1]
 
 
 def write_bit32(data):

--- a/binary/unsigned_integer/reader.py
+++ b/binary/unsigned_integer/reader.py
@@ -10,7 +10,7 @@ def read_bit8(data, offset=0):
     Returns:
         int
     """
-    return unpack_from('C', data, offset)[1]
+    return unpack_from('B', data, offset)[1]
 
 
 def read_bit16(data, offset=0, endianness=False):
@@ -23,11 +23,11 @@ def read_bit16(data, offset=0, endianness=False):
         int
     """
     if endianness is True:
-        value = unpack_from('n', data, offset)[1]  # big-endian
+        value = unpack_from('>H', data, offset)[1]  # big-endian
     elif endianness is False:
-        value = unpack_from('v', data, offset)[1]  # little-endian
+        value = unpack_from('<H', data, offset)[1]  # little-endian
     elif endianness is None:
-        value = unpack_from('S', data, offset)[1]  # machine byte order
+        value = unpack_from('=H', data, offset)[1]  # machine byte order
     else:
         raise Exception('Invalid value "{}" for endianness given'.format(endianness))
     return value
@@ -43,9 +43,9 @@ def read_bit32(data, offset=0, endianness=False):
         int
     """
     if endianness is True:
-        value = unpack_from('N', data, offset)[1]  # big-endian
+        value = unpack_from('>L', data, offset)[1]  # big-endian
     elif endianness is False:
-        value = unpack_from('V', data, offset)[1]  # little-endian
+        value = unpack_from('<L', data, offset)[1]  # little-endian
     elif endianness is None:
         value = unpack_from('L', data, offset)[1]  # machine byte order
     else:
@@ -63,9 +63,9 @@ def read_bit64(data, offset=0, endianness=False):
         int
     """
     if endianness is True:
-        value = unpack_from('J', data, offset)[1]  # big-endian
+        value = unpack_from('>Q', data, offset)[1]  # big-endian
     elif endianness is False:
-        value = unpack_from('P', data, offset)[1]  # little-endian
+        value = unpack_from('<Q', data, offset)[1]  # little-endian
     elif endianness is None:
         value = unpack_from('Q', data, offset)[1]  # machine byte order
     else:

--- a/binary/unsigned_integer/writer.py
+++ b/binary/unsigned_integer/writer.py
@@ -2,7 +2,7 @@ from struct import pack
 
 
 def write_bit8(data):
-    return pack('C', data)
+    return pack('B', data)
 
 
 def write_bit16(data, endianness=False):
@@ -16,11 +16,11 @@ def write_bit16(data, endianness=False):
     """
 
     if endianness is True:
-        value = pack('n', data)  # big-endian
+        value = pack('>H', data)  # big-endian
     elif endianness is False:
-        value = pack('v', data)  # little-endian
+        value = pack('<H', data)  # little-endian
     elif endianness is None:
-        value = pack('S', data)  # machine byte order
+        value = pack('H', data)  # machine byte order
     else:
         raise Exception('Invalid value "{}" for endianness given'.format(endianness))
     return value
@@ -36,9 +36,9 @@ def write_bit32(data, endianness=False):
         bytes: bytes object containing value from data
     """
     if endianness is True:
-        value = pack('N', data)  # big-endian
+        value = pack('>L', data)  # big-endian
     elif endianness is False:
-        value = pack('V', data)  # little-endian
+        value = pack('<L', data)  # little-endian
     elif endianness is None:
         value = pack('L', data)  # machine byte order
     else:
@@ -56,9 +56,9 @@ def write_bit64(data, endianness=False):
         bytes: bytes object containing value from data
     """
     if endianness is True:
-        value = pack('J', data)  # big-endian
+        value = pack('>Q', data)  # big-endian
     elif endianness is False:
-        value = pack('P', data)  # little-endian
+        value = pack('<Q', data)  # little-endian
     elif endianness is None:
         value = pack('Q', data)  # machine byte order
     else:


### PR DESCRIPTION
This structure was initially copied from PHP's code which uses different formats in pack. [PHP](https://secure.php.net/manual/en/function.pack.php) vs [Python](https://docs.python.org/3.6/library/struct.html#struct.calcsize). Unfortunately, Python's pack doesn't allow formats for Hex string, low/high nibble first so that I still need to figure out how it's done.